### PR TITLE
Fix/filter recipes

### DIFF
--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -260,6 +260,10 @@ main {
   display: none !important;
 }
 
+.hidden {
+  display: none !important;
+}
+
 .recipe--card:hover .recipe--photo {
   opacity: 50%;
   transition: .8s ease;

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -145,7 +145,12 @@ function findTaggedRecipes(selected) {
     })
   });
 
-  showAllRecipes();
+  if (main.classList.value === 'display-favorites') {
+    showSavedRecipes();
+  } else {  
+    showAllRecipes();
+  }
+
   if (filteredResults.length > 0) {
     filterRecipes(filteredResults);
   }
@@ -197,7 +202,7 @@ function removeFromFavorites(cardId, recipeCard, cardClass) {
 }
 
 function showSavedRecipes() {
-  main.classList.add('display-favorites')
+  main.classList.value = ('display-favorites')
   showMyRecipesBanner()
 }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -119,10 +119,6 @@ function findTags() {
   domUpdates.addListTags(tags);
 }
 
-// press button, fires findCHeckedBoxes
-// findCheckedBoxes gets an array from all of the tags in the list, then filters them based on their chedked value and passes thos into findTaggedRecipes
-// findTaggedRecipes forEachs the argued array of html Elements that are checked boxes
-
 function findCheckedBoxes() {
   let tagCheckboxes = document.querySelectorAll(".checked-tag");
   let checkboxInfo = Array.from(tagCheckboxes)
@@ -135,7 +131,7 @@ function findCheckedBoxes() {
 function findTaggedRecipes(selected) {
   let filteredResults = [];
   selected.forEach(tag => {
-    let recipes = recipeData.filter(recipe => {
+    let recipes = allRecipes.filter(recipe => {
       return recipe.tags.includes(tag.id);
     });
     recipes.forEach(recipe => {
@@ -146,6 +142,7 @@ function findTaggedRecipes(selected) {
   });
 
   if (main.classList.value === 'display-favorites') {
+    showAllRecipes();
     showSavedRecipes();
   } else {  
     showAllRecipes();
@@ -157,7 +154,7 @@ function findTaggedRecipes(selected) {
 }
 
 function filterRecipes(filtered) {
-  let foundRecipes = recipeData.filter(recipe => {
+  let foundRecipes = allRecipes.filter(recipe => {
     return !filtered.includes(recipe);
   });
   hideUnselectedRecipes(foundRecipes)

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -119,6 +119,10 @@ function findTags() {
   domUpdates.addListTags(tags);
 }
 
+// press button, fires findCHeckedBoxes
+// findCheckedBoxes gets an array from all of the tags in the list, then filters them based on their chedked value and passes thos into findTaggedRecipes
+// findTaggedRecipes forEachs the argued array of html Elements that are checked boxes
+
 function findCheckedBoxes() {
   let tagCheckboxes = document.querySelectorAll(".checked-tag");
   let checkboxInfo = Array.from(tagCheckboxes)
@@ -134,12 +138,13 @@ function findTaggedRecipes(selected) {
     let recipes = recipeData.filter(recipe => {
       return recipe.tags.includes(tag.id);
     });
-    recipeData.forEach(recipe => {
+    recipes.forEach(recipe => {
       if (!filteredResults.includes(recipe)) {
         filteredResults.push(recipe);
       }
     })
   });
+
   showAllRecipes();
   if (filteredResults.length > 0) {
     filterRecipes(filteredResults);

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -94,7 +94,7 @@ function createCards() {
     domUpdates.addCardToDom(recipe, recipeName)
     createCardListeners()
   })
-  console.log(allRecipes);
+  // console.log(allRecipes);
 }
 
 function createCardListeners() {
@@ -106,64 +106,61 @@ function createCardListeners() {
 
 // FILTER BY RECIPE TAGS
 function findTags() {
-  let tags = [];
-  recipeData.forEach(recipe => {
+  const tags = []
+
+  allRecipes.forEach(recipe => {
     recipe.tags.forEach(tag => {
       if (!tags.includes(tag)) {
-        tags.push(tag);
+        tags.push(tag)
       }
-    });
-  });
-  tags.sort();
-  domUpdates.addListTags(tags);
+    })
+  })
+ 
+  tags.sort()
+  domUpdates.addListTags(tags)
 }
 
 function findCheckedBoxes() {
-  let tagCheckboxes = document.querySelectorAll(".checked-tag");
-  let checkboxInfo = Array.from(tagCheckboxes)
-  let selectedTags = checkboxInfo.filter(box => {
-    return box.checked;
+  const tagCheckBoxes = document.querySelectorAll('.checked-tag')
+  const checkBoxInfo = Array.from(tagCheckBoxes)
+
+  const selectedTags = checkBoxInfo.filter(box => {
+    return box.checked
   })
-  findTaggedRecipes(selectedTags);
+
+  unhideRecipeCards()
+  findUntaggedRecipes(selectedTags)
 }
 
-function findTaggedRecipes(selected) {
-  let filteredResults = [];
+function unhideRecipeCards() {
+  const allCards = document.querySelectorAll('.recipe--card')
+
+  allCards.forEach(card => card.classList.remove('hidden'))
+}
+
+function findUntaggedRecipes(selected) {
+  const filteredRecipes = []
+
   selected.forEach(tag => {
-    let recipes = allRecipes.filter(recipe => {
-      return recipe.tags.includes(tag.id);
-    });
+    const recipes = allRecipes.filter(recipe => {
+      return !recipe.tags.includes(tag.id)
+    })
+
     recipes.forEach(recipe => {
-      if (!filteredResults.includes(recipe)) {
-        filteredResults.push(recipe);
+      if (!filteredRecipes.includes(recipe)) {
+        filteredRecipes.push(recipe)
       }
     })
-  });
+  })
 
-  if (main.classList.value === 'display-favorites') {
-    showAllRecipes();
-    showSavedRecipes();
-  } else {  
-    showAllRecipes();
-  }
-
-  if (filteredResults.length > 0) {
-    filterRecipes(filteredResults);
-  }
+  hideUntaggedRecipes(filteredRecipes)
 }
 
-function filterRecipes(filtered) {
-  let foundRecipes = allRecipes.filter(recipe => {
-    return !filtered.includes(recipe);
-  });
-  hideUnselectedRecipes(foundRecipes)
-}
-
-function hideUnselectedRecipes(foundRecipes) {
+function hideUntaggedRecipes(foundRecipes) {
   foundRecipes.forEach(recipe => {
-    let domRecipe = document.getElementById(`${recipe.id}`);
-    domRecipe.style.display = "none";
-  });
+    const domRecipe = document.getElementById(`${recipe.id}`)
+    domRecipe.classList.add('hidden')
+  })
 }
 
 // FAVORITE RECIPE FUNCTIONALITY
@@ -304,10 +301,10 @@ function togglePantryDisplay() {
 function showAllRecipes() {
   allRecipes.forEach(recipe => {
     let domRecipe = document.getElementById(`${recipe.id}`)
-    domRecipe.style.display = "block"
+    domRecipe.style.display = 'block'
   })
 
-  main.classList.remove("display-favorites")
+  main.classList.remove('display-favorites')
   showWelcomeBanner()
 }
 


### PR DESCRIPTION
## *Purpose:*
*What does this merge do? Check all that apply.*
- [x] Adds a new feature
- [x] Improves an existing feature
- [x] Fixes a bug
- [ ] Cleans up (logs, tests, etc.)


## *Description: What does this PR do?*
*Briefly, but clearly describe what you did, and explain any new code.*
- the functionality that filters recipes by their tags was broken. I got it to work, but it was really clumsy and wanky. 
- Now, the filtering functionality grabs all of the selected checkboxes on the left side of the screen then filters recipe cards by their id and hides the recipe cards whose tags do not include the selected tags
- the original functionality was redisplaying all of the cards before each new filter, but now it just toggles a hidden class 
- the filter is built to filter more strictly with more selected tags. So, if the use selects two tags, the page will only show results that meet **both** requirements, **not** either

## *Instructions for reviewer:*
*Where should the reviewer start?*
- open the page with the servers running 
- `scripts.js` lines 107-165

*How should this be manually tested?*
1. selected a tag on the left side and click filter recipes
   -  you should see only the recipes whose tags include your selection 

2. uncheck the checked box and click the button again 
   - you should see all of the recipe cards again

3. favorite more than one recipe card by clicking on the apple in the bottom right corner of any card and then view favorite recipes by clicking my recipes in the top right of the page 
  - repeat steps one and two but make sure that you are still only seeing favorited recipes 
 
*Any background context you want to provide?*
- abandon all hope ye who also thinks this should've been much, much easier than it was 

*What are the relevant tickets?*
- closes #7 



## *Issues:*
*Are there any concerns, issues, or bugs in this branch? If so describe them.*



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have used tests to prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my change
